### PR TITLE
fix custom query

### DIFF
--- a/lib/kaffy/resource_admin.ex
+++ b/lib/kaffy/resource_admin.ex
@@ -410,6 +410,16 @@ defmodule Kaffy.ResourceAdmin do
     )
   end
 
+  def custom_index_count_query(conn, resource, query) do
+    Utils.get_assigned_value_or_default(
+      resource,
+      :custom_index_count_query,
+      query,
+      [conn, resource[:schema], query],
+      false
+    )
+  end
+
   def custom_show_query(conn, resource, query) do
     Utils.get_assigned_value_or_default(
       resource,

--- a/lib/kaffy/resource_query.ex
+++ b/lib/kaffy/resource_query.ex
@@ -34,6 +34,15 @@ defmodule Kaffy.ResourceQuery do
           {Kaffy.Utils.repo().all(custom_query), []}
       end
 
+    all =
+      case Kaffy.ResourceAdmin.custom_index_count_query(conn, resource, all) do
+        {custom_query, opts} ->
+          custom_query
+
+        custom_query ->
+          custom_query
+      end
+
     do_cache = if search == "" and Enum.empty?(filtered_fields), do: true, else: false
     all_count = cached_total_count(schema, do_cache, all, opts)
     {all_count, current_page}


### PR DESCRIPTION
Use custom query when counting the total number of records instead of the default query.

When using the custom query option, the total counts should be also done using the custom query.

